### PR TITLE
Fix asynchronous function return type

### DIFF
--- a/lib/approov_service_flutter_httpclient.dart
+++ b/lib/approov_service_flutter_httpclient.dart
@@ -260,7 +260,7 @@ class ApproovService {
   ///
   /// @param config is the configuration string
   /// @param comment is an optional comment used during initialization or null if not required
-  static void initialize(String config, [String? comment]) async {
+  static Future<void> initialize(String config, [String? comment]) async {
     if (_futureInitialization != null) {
       // ensure we wait in case initialize has been called previously
       await _futureInitialization;


### PR DESCRIPTION
`initialize` function is asynchronous and to be able to await it it has to have Future return type.