### PR TITLE
Rerouted MethodChannel handling onto background threads to avoid bloc…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ AGENTS.md
 build/
 # Exclude .json test files used for testing only. 
 test/third_party/structured_field_tests/ 
+test/third_party.zip

--- a/ios/Classes/ApproovHttpClientPlugin.m
+++ b/ios/Classes/ApproovHttpClientPlugin.m
@@ -415,6 +415,18 @@ static const NSTimeInterval FETCH_CERTIFICATES_TIMEOUT = 3;
 }
 
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
+    FlutterResult mainThreadResult = ^(id _Nullable value) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            result(value);
+        });
+    };
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [self handleMethodCallInternal:call result:mainThreadResult];
+    });
+}
+
+- (void)handleMethodCallInternal:(FlutterMethodCall *)call result:(FlutterResult)result {
+    NSLog(@"Is main thread: %@", [NSThread isMainThread] ? @"YES" : @"NO");
     if ([@"initialize" isEqualToString:call.method]) {
         // get the initialization arguments
         NSError* error = nil;


### PR DESCRIPTION
…king the main/UI thread and kept callbacks to Flutter on the main thread, so long-running SDK waits won’t ANR in Flutter 3.29+.

Android:
android/src/main/java/com/criticalblue/approov_service_flutter_httpclient/ApproovHttpClientPlugin.java: Added a dedicated HandlerThread/Handler, dispatch onMethodCall work to it, clean it up on detach, and log thread status inside the worker handler.

IOS:
ios/Classes/ApproovHttpClientPlugin.m: Wrapped handleMethodCall: to run work on a global background queue while marshalling results back to the main queue; thread log now runs inside the worker path.